### PR TITLE
Add corners info in pickle file

### DIFF
--- a/CombCount.py
+++ b/CombCount.py
@@ -372,7 +372,8 @@ def report_results():
              "capped_polygons" : capped_polygons,
              "honey_polygons"  : honey_polygons,
              "circles"         : circles,
-             "spacing"         : spacing}
+             "spacing"         : spacing,
+             "corners"         : corners }
     pickle.dump(stats, open("".join(sys.argv[1].split(".")[:-1])+"-stats.pickle", "wb"))
 
     # print summary


### PR DESCRIPTION
I just add corners info into the pickle file.
This was missing if one want to replay the annotation process.